### PR TITLE
folder2csv: fixed compatibility with magic

### DIFF
--- a/folder2csv.py
+++ b/folder2csv.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
         fname = os.path.basename(path)
 
         with open(path, 'rb') as fp:
-            finfo = (fname, fp, magic.detect_from_filename(path).mime_type)
+            finfo = (fname, fp, magic.from_file(path))
             did = api.post_document(finfo)['id']
         r = api.poll_document(did)
 


### PR DESCRIPTION
magic no longer has a function `detect_from_filename()`, instead contains an equivalent function `from_file()` 